### PR TITLE
WIP: Set course start and end dates if valid dates passed via env.

### DIFF
--- a/import.sh
+++ b/import.sh
@@ -6,9 +6,11 @@ set -o pipefail
 
 VIA_CURL=""
 IMPORTER="$PWD/importer.py"
-BASE_URL="https://raw.githubusercontent.com/appsembler/msft-courses/master"
+BASE_URL="https://raw.githubusercontent.com/bryanlandia/msft-courses/bryan/feature/set-course-start-end-date"
 COURSES_DIR="$PWD"
 DATA_DIR="/edx/var/edxapp/data/"
+COURSE_START_DATE=${COURSE_START_DATE:=""}
+COURSE_END_DATE=${COURSE_END_DATE:=""}
 
 cleanup_data_dir() {
     sudo find "$DATA_DIR" -maxdepth 1 -mindepth 1 -exec rm -rf "{}" \;
@@ -33,6 +35,6 @@ fi
 cleanup_data_dir
 
 CMS_SHELL="sudo -u edxapp /edx/bin/python.edxapp /edx/bin/manage.edxapp lms --settings=$EDXAPP_ENV shell"
-echo "__file__='$IMPORTER'; COURSES_DIR='$COURSES_DIR'; execfile(__file__);" | $CMS_SHELL
+echo "__file__='$IMPORTER'; COURSES_DIR='$COURSES_DIR'; COURSE_START_DATE='$COURSE_START_DATE'; COURSE_END_DATE='$COURSE_END_DATE'; execfile(__file__);" | $CMS_SHELL
 
 cleanup_data_dir

--- a/importer.py
+++ b/importer.py
@@ -1,7 +1,9 @@
+import dateutil
 import json
 from glob import glob
 import subprocess
 from os import path, walk, mkdir, makedirs, listdir
+from pytz import utc
 import fileinput
 import yaml
 import sys
@@ -40,6 +42,40 @@ def _get_courses_dir():
     This is set via `import.sh` at run time.
     """
     return COURSES_DIR
+
+
+def _get_course_start_date():
+    """
+    This is set via `import.sh` at run time.
+    """
+    if COURSE_START_DATE:
+        try:
+            start = dateutil.parser.parse(COURSE_START_DATE)
+        except (AttributeError, ValueError):
+            return False
+
+        if start.tzinfo is None:
+            start = start.replace(tzinfo=utc)
+        return start
+    else:
+        return False
+
+
+def _get_course_end_date():
+    """
+    This is set via `import.sh` at run time.
+    """
+    if COURSE_END_DATE:
+        try:
+            end = dateutil.parser.parse(COURSE_END_DATE)
+        except (AttributeError, ValueError):
+            return False
+
+        if end.tzinfo is None:
+            end = end.replace(tzinfo=utc)
+        return end
+    else:
+        return False
 
 
 def _read_file_in_tgz(filename, sub_filename):
@@ -121,6 +157,20 @@ def _fix_library_source_bug(course_xml_dir):
             library_f.write(str(lib_element))
 
 
+def _set_course_dates(course_id):
+    start = _get_course_start_date()
+    end = _get_course_end_date()
+    if not (start and end):
+        return
+
+    print >> sys.stderr, 'setting course start and end dates for ', course_id
+    course = MOD_STORE.get_course(course_id)
+    course.start = start
+    course.end = end
+    course.save()
+    MOD_STORE.update_item(course, course._edited_by)
+
+
 def import_single_course(filename):
     print >> sys.stderr, 'IMPORTING course:', filename
     course_id, course_run = _filename_to_id_and_run(filename)
@@ -156,6 +206,7 @@ def import_single_course(filename):
         if not are_permissions_roles_seeded(course_id):
             print >> sys.stderr, 'Seeding forum roles for course', course_id
             seed_permissions_roles(course_id)
+        _set_course_dates(course_id)
 
 
 def import_single_library(filename):


### PR DESCRIPTION
Hey Omar, 

I tried to get this to work since Epic has asked to change the start and end dates and they are importing a lot of courses at once.  It does except I never see any change in the start and end date form fields in the Settings > Schedule & Details page (/settings/details/course-v1:...).  I've done updates like this before, set a value like `course.field = "foo"`, called `store.update_item(course, course._edited_by)` and the change persists in the modulestore.  I don't know what might not be working here. I'm not getting any `ValueError` or any problem converting my `dateutil` parsed datetime into the field value, for this: https://github.com/appsembler/edx-platform/blob/appsembler/ficus/master/common/lib/xmodule/xmodule/course_module.py#L184-L188

 Any ideas?

To use:

```
export COURSE_START_DATE=2018-01-01 COURSE_END_DATE=2019-12-31
curl https://raw.githubusercontent.com/bryanlandia/msft-courses/bryan/feature/set-course-start-end-date/import.sh | bash
```

(note, this commit changes the BASE_URL to this dev fork/branch in `import.sh` )

I also need to do a bit more testing on behavior when no COURSE_START_DATE or COURSE_END_DATE are passed via env.  

Thanks!