### PR TITLE
Set course start and end dates if valid dates passed via env

### DIFF
--- a/README.md
+++ b/README.md
@@ -57,9 +57,10 @@ course-v1:Microsoft+DEV281x+2017_T4
    suffix before the import.
 
 ### Executing the Import Script
-Run the following command:
+Run the following command, the dates are optional, but recommended:
 
 ```bash
+export COURSE_START_DATE=2018-01-01 COURSE_END_DATE=2019-12-31  # Optional, but recommended
 $ curl https://raw.githubusercontent.com/appsembler/msft-courses/master/import.sh | bash
 ```
 

--- a/import.sh
+++ b/import.sh
@@ -4,11 +4,10 @@ set -x
 set -o pipefail
 
 
-VIA_CURL=""
-IMPORTER="$PWD/importer.py"
-BASE_URL="https://raw.githubusercontent.com/appsembler/msft-courses/master"
 COURSES_DIR="$PWD"
 DATA_DIR="/edx/var/edxapp/data/"
+COURSE_START_DATE=${COURSE_START_DATE:=""}
+COURSE_END_DATE=${COURSE_END_DATE:=""}
 
 cleanup_data_dir() {
     sudo find "$DATA_DIR" -maxdepth 1 -mindepth 1 -exec rm -rf "{}" \;
@@ -22,17 +21,20 @@ fi
 
 if [ "$0" == "bash" ]; then
     if [ -z "$1" ]; then
-        VIA_CURL="true"
+        BASE_URL="https://raw.githubusercontent.com/appsembler/msft-courses/master"
         IMPORTER=$(mktemp /tmp/abc-script.XXXXXXXX)
         curl "$BASE_URL/importer.py" | tee "$IMPORTER"
         chmod a+wrx "$IMPORTER"
     fi
+else
+    SCRIPT_DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" >/dev/null && pwd )"
+    IMPORTER="$SCRIPT_DIR/importer.py"
 fi
 
 
 cleanup_data_dir
 
-CMS_SHELL="sudo -u edxapp /edx/bin/python.edxapp /edx/bin/manage.edxapp lms --settings=$EDXAPP_ENV shell"
-echo "__file__='$IMPORTER'; COURSES_DIR='$COURSES_DIR'; execfile(__file__);" | $CMS_SHELL
+CMS_SHELL="sudo -u edxapp /edx/bin/python.edxapp /edx/bin/manage.edxapp cms --settings=$EDXAPP_ENV shell"
+echo "__file__='$IMPORTER'; COURSES_DIR='$COURSES_DIR'; COURSE_START_DATE='$COURSE_START_DATE'; COURSE_END_DATE='$COURSE_END_DATE'; execfile(__file__);" | $CMS_SHELL
 
 cleanup_data_dir

--- a/replace.sh
+++ b/replace.sh
@@ -4,15 +4,13 @@ set -x
 set -o pipefail
 
 
-VIA_CURL=""
-IMPORTER="$PWD/replacer.py"
+REPLACER="$PWD/replacer.py"
 BASE_URL="https://raw.githubusercontent.com/appsembler/msft-courses/master"
 
 
 if [ "$0" == "bash" ]; then
     if [ -z "$1" ]; then
-        VIA_CURL="true"
-        IMPORTER=$(mktemp /tmp/abc-script.XXXXXXXX)
+        REPLACER=$(mktemp /tmp/abc-script.XXXXXXXX)
         curl "$BASE_URL/replacer.py" | tee "$REPLACER"
         chmod a+wrx "$REPLACER"
     fi


### PR DESCRIPTION
Cleanup and re-open of #7


### How to Use
```
export COURSE_START_DATE=2018-01-01 COURSE_END_DATE=2019-12-31
curl https://raw.githubusercontent.com/bryanlandia/msft-courses/omar/feature/import-start-date/import.sh | sed s=master=omar/import-start-date= | bash
```

### TODO

 - [x] Update README
 - [x] Enrollment start and end dates (probably not needed)
 - [x] Set the shell to [CMS](https://openedx.slack.com/archives/C12M8M5AR/p1530016275000327)
 - [x] Test it on a devstack
 - [ ] Test it on a customer site
